### PR TITLE
login user list z-index fix

### DIFF
--- a/src/cljs/back_channeling/components/board.cljs
+++ b/src/cljs/back_channeling/components/board.cljs
@@ -393,7 +393,8 @@
          {:class "fixed"
           :style {:margin-top "66px"
                   :width "874px"
-                  :background-color "#ffffff"}})
+                  :background-color "#ffffff"
+                  :z-index "1"}})
         (for [tab tabs]
           [:a.item (merge {:on-click (fn [_]
                                (set! (.-href js/location)


### PR DESCRIPTION
一番うえまでスクロールせずともログインユーザ一覧が表示されるようにする。
